### PR TITLE
Feature THREE.js+Qt Gui

### DIFF
--- a/nfem/canvas_3d.py
+++ b/nfem/canvas_3d.py
@@ -77,6 +77,11 @@ class Canvas3D:
         return template
 
     def html(self, height, model):
+        content = self.raw_html(height, model)
+
+        return f'<iframe seamless frameborder="0" allowfullscreen width="100%" height="{height}" srcdoc="{html.escape(content)}"></iframe>'
+
+    def raw_html(self, height, model):
         timesteps_data = []
 
         for model in model.get_model_history():
@@ -116,7 +121,8 @@ class Canvas3D:
         template = self._embed_js(template, 'index.js')
 
         content = template.replace("const data = {}", "const data = " + json.dumps(data))
-        return f'<iframe seamless frameborder="0" allowfullscreen width="100%" height="{height}" srcdoc="{html.escape(content)}"></iframe>'
+        
+        return content
 
     def show(self, height, model):
         display_html(self.html(height, model), raw=True)

--- a/nfem/model.py
+++ b/nfem/model.py
@@ -1136,6 +1136,13 @@ class Model:
 
         return canvas.html(600, self)
 
+    def html(self) -> str:
+        from nfem.canvas_3d import Canvas3D
+
+        canvas = Canvas3D(height=600)
+
+        return canvas.raw_html(600, self)
+
     def show(self, height: int = 600, timestep: int = 0) -> None:
         """Show the model."""
         from nfem.canvas_3d import Canvas3D

--- a/nfem/model.py
+++ b/nfem/model.py
@@ -1145,8 +1145,23 @@ class Model:
 
     def show(self, height: int = 600, timestep: int = 0) -> None:
         """Show the model."""
-        from nfem.canvas_3d import Canvas3D
+        try:
+            from nfem.canvas_3d import Canvas3D
+            canvas = Canvas3D(height=height)
+            canvas.show(height, self)
+        except (ImportError, NameError):
+            from PyQt6.QtWebEngineWidgets import QWebEngineView
+            from PyQt6.QtWidgets import QApplication
 
-        canvas = Canvas3D(height=height)
+            import sys
 
-        canvas.show(height, self)
+            html = self.html()
+
+            app = QApplication(sys.argv)
+
+            view = QWebEngineView()
+            view.setWindowTitle('nfem')
+            view.setHtml(html)
+            view.show()
+
+            sys.exit(app.exec())

--- a/poetry.lock
+++ b/poetry.lock
@@ -1036,14 +1036,14 @@ test = ["pytest"]
 
 [[package]]
 name = "testpath"
-version = "0.5.0"
+version = "0.6.0"
 description = "Test utilities for code working with files and commands"
 category = "main"
 optional = false
 python-versions = ">= 3.5"
 
 [package.extras]
-test = ["pytest", "pathlib2"]
+test = ["pytest"]
 
 [[package]]
 name = "toml"
@@ -1124,10 +1124,13 @@ python-versions = ">=3.7"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
+[extras]
+qt = []
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "8b484d535fa58f88ab4e5245499b0da844820a4cc1d74c2c8902bb64512b60d0"
+content-hash = "fb74ee4d151768045c7ffee0dbaf672b8dd3eabaedfec204acfa2937d8e291e8"
 
 [metadata.files]
 appnope = [
@@ -1774,8 +1777,8 @@ terminado = [
     {file = "terminado-0.13.1.tar.gz", hash = "sha256:5b82b5c6e991f0705a76f961f43262a7fb1e55b093c16dca83f16384a7f39b7b"},
 ]
 testpath = [
-    {file = "testpath-0.5.0-py3-none-any.whl", hash = "sha256:8044f9a0bab6567fc644a3593164e872543bb44225b0e24846e2c89237937589"},
-    {file = "testpath-0.5.0.tar.gz", hash = "sha256:1acf7a0bcd3004ae8357409fc33751e16d37ccc650921da1094a86581ad1e417"},
+    {file = "testpath-0.6.0-py3-none-any.whl", hash = "sha256:8ada9f80a2ac6fb0391aa7cdb1a7d11cfa8429f693eda83f74dde570fe6fa639"},
+    {file = "testpath-0.6.0.tar.gz", hash = "sha256:2f1b97e6442c02681ebe01bd84f531028a7caea1af3825000f52345c30285e0f"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ scipy = [
 importlib-metadata = { version = "^4.11", python = "<3.8" }
 typing-extensions = { version = "^4.1.1", python = "<3.8" }
 
+[tool.poetry.extras]
+qt = ["PyQt6-WebEngine"]
+
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"
 mypy = "^0.931"

--- a/window.py
+++ b/window.py
@@ -1,0 +1,50 @@
+import nfem
+import numpy as np
+
+model = nfem.Model()
+
+model.add_node('A', x=0, y=0, z=0, support='xyz')
+model.add_node('B', x=1, y=1, z=0, support='z', fy=-1)
+model.add_node('C', x=2, y=0, z=0, support='xyz')
+
+model.add_truss('1', node_a='A', node_b='B', youngs_modulus=1, area=1)
+model.add_truss('2', node_a='B', node_b='C', youngs_modulus=1, area=1)
+
+for t in np.linspace(0, 1, 10):
+    model.load_factor = t
+    model.perform_load_control_step()
+
+model.show()
+
+
+# from PyQt6.QtWebEngineWidgets import QWebEngineView
+# from PyQt6.QtWidgets import QApplication
+
+# import sys
+
+# HTML = r"""
+# <!DOCTYPE html>
+# <html lang="en">
+# <head>
+#     <meta charset="UTF-8">
+#     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+#     <title>Home page</title>
+# </head>
+# <body>
+#     <p>
+#         This is a simple HTML page.
+#     </p>
+# </body>
+# </html>
+# """
+
+
+# with open('test.html', 'w', encoding='utf-8') as f:
+#     f.write(model.html())
+
+
+# import os
+
+# os.environ["QTWEBENGINE_DISABLE_SANDBOX"] = "1"
+
+


### PR DESCRIPTION
@arpastrana

Open viewer from classic script without Jupyter by adding an optional PyQt6 dependency.

Install in developer mode using:
`pip install -e .[qt]`

Run a nfem script e.g.:
```python
import nfem
import numpy as np

model = nfem.Model()

model.add_node('A', x=0, y=0, z=0, support='xyz')
model.add_node('B', x=1, y=1, z=0, support='z', fy=-1)
model.add_node('C', x=2, y=0, z=0, support='xyz')

model.add_truss('1', node_a='A', node_b='B', youngs_modulus=1, area=1)
model.add_truss('2', node_a='B', node_b='C', youngs_modulus=1, area=1)

for t in np.linspace(0, 1, 10):
    model.load_factor = t
    model.perform_load_control_step()

model.show()
```

https://user-images.githubusercontent.com/7000594/155566536-a9a94f3a-056a-4982-8e3f-dcf0b27d059e.mp4

